### PR TITLE
refactor: sentry 개발에만 적용하도록 수정

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,8 @@ services:
       - "8000:8000"
     networks:
       - app-network
+    env_file:
+      - .env.test
 
 networks:
   app-network:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,8 +62,6 @@ services:
       - "8000:8000"
     networks:
       - app-network
-    env_file:
-      - .env.test
 
 networks:
   app-network:

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,22 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import * as Sentry from "@sentry/react";
+import { browserTracingIntegration } from "@sentry/react";
 import App from './App.jsx';
 import './index.css';
 
-Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN,
-  integrations: [],
-});
+// 모니터링 툴 - 개발 서버에서만 실행
+if (import.meta.env.MODE === 'development') {
+  Sentry.init({
+    dsn: import.meta.env.VITE_SENTRY_DSN,
+    integrations: [
+      browserTracingIntegration({
+        tracingOrigins: ['*'],
+      }),
+    ],
+    tracesSampleRate: 1.0,
+  });
+}
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,13 +10,17 @@ export default defineConfig(({ command, mode }) => {
     plugins: [
       react(),
       sentryVitePlugin({
-        authToken: process.env.SENTRY_AUTH_TOKEN,
+        authToken: env.SENTRY_AUTH_TOKEN,
         org: "parrotalk",
         project: "javascript-react",
+        release: env.VITE_RELEASE || "default-release",
+        sourcemaps: {
+          assets: "./dist/**",
+        },
       }),
     ],
     build: {
-      sourcemap: false, // 에러위치 잡기, 빌드시 꺼둠
+      sourcemap: true, // 에러위치 잡기, 빌드시 꺼둠
     },
     server: {
       proxy: {


### PR DESCRIPTION
 ## 📌 개요
  - sentry 개발에서만 모니터링 가능하도록 수정
 ## 💻 작업사항
  - main에 sentry 개발에서만 작동하도록 조건문 추가
 ## 📊 테스트 결과
  -
<img width="677" alt="image" src="https://github.com/user-attachments/assets/a2843431-9b05-45e0-aeb1-c3a7d9945046">

 ## 💡Issue 번호
  - #55