### PR TITLE
fix : 요약이 리셋되어 한사람한테만 뜨는 버그 해결

### DIFF
--- a/server.js
+++ b/server.js
@@ -199,10 +199,15 @@ wsServer.on('connection', socket => {
       });
   }
 
+  
+
   // 방 퇴장 로직
   socket.on('leave_room', async data => {
     const { roomName, chatMessages } = data;
-    requestAISummary(roomName, chatMessages);
+    if (!rooms[`${roomName}_chatMessages`]) {
+      rooms[`${roomName}_chatMessages`] = chatMessages;
+    }
+    requestAISummary(roomName, rooms[`${roomName}_chatMessages`]);
 
     socket.off('audio_chunk', handleAudioChunk);
     console.log(`[Audio] audio_chunk listener removed for room: ${roomName}`);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 요약이 리셋되어 한사람한테만 뜨는 버그 해결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. 새 패키지가 설치되었다면 여기에 반드시 명시해 주세요. -->
  - 서버에 chatMessages를 저장해놓는다.
  - 다음 leave_room 이벤트가 발생될때 빈값으로 들어온 chatMessages가 초기화를 하니 if문으로 값이 들어가 있다면 값을 넣지 않는다.

 ## 📊 테스트 결과 <!-- 테스트 결과를 간단히 적어주시거나 스크린샷을 첨부해 주세요 -->
  <img width="700" alt="image" src="https://github.com/user-attachments/assets/47f4afec-dff3-492c-8698-9309b810b096">
<img width="322" alt="image" src="https://github.com/user-attachments/assets/58ffbb54-85e2-4d2d-8767-6c62675cc37c">

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
  - #51 