### PR TITLE
fix : 요약 요청을 socket에서 axios로 변경 & 상대방과 받는 todo 통일하기

### DIFF
--- a/server.js
+++ b/server.js
@@ -167,38 +167,6 @@ wsServer.on('connection', socket => {
     socket.to(roomName).emit('ice', ice);
   });
 
-  function requestAISummary(roomName, messages) {
-    // 요약 요청
-    console.log('roomName: ' + roomName);
-    const combinedContent = messages.map(msg => msg.content).join(' ');
-    console.log('message: ' + combinedContent);
-
-    // 실제 요약 요청
-    const aiRequest = axios
-      .post(process.env.AI_SUMMARY, {
-        room_number: roomName,
-        sentence: combinedContent,
-      })
-      .then(response => {
-        // 성공적인 요청 처리
-        const { summary, todo } = response.data;
-        console.log(todo);
-        socket.emit('ai_summary', todo);
-      })
-      .catch(error => {
-        if (error.code === 'ECONNREFUSED') {
-          console.error(
-            'SUMMARY : Connection refused. Please check the server status.'
-          );
-        } else {
-          console.error(
-            'SUMMARY : An unexpected error occurred:',
-            error.message
-          );
-        }
-      });
-  }
-
   socket.on('ai_summary', (roomName, todo) => {
     rooms[`${roomName}_todo`] = todo;
   });
@@ -216,10 +184,6 @@ wsServer.on('connection', socket => {
   // 방 퇴장 로직
   socket.on('leave_room', async data => {
     const { roomName } = data;
-    // if (!rooms[`${roomName}_chatMessages`]) {
-    //   rooms[`${roomName}_chatMessages`] = chatMessages;
-    // }
-    // requestAISummary(roomName, rooms[`${roomName}_chatMessages`]);
 
     socket.off('audio_chunk', handleAudioChunk);
     console.log(`[Audio] audio_chunk listener removed for room: ${roomName}`);

--- a/server.js
+++ b/server.js
@@ -199,15 +199,27 @@ wsServer.on('connection', socket => {
       });
   }
 
-  
+  socket.on('ai_summary', (roomName, todo) => {
+    rooms[`${roomName}_todo`] = todo;
+  });
+
+  // Todo 데이터 요청 처리
+  socket.on('fetch_todo', (roomName, callback) => {
+    const todo = rooms[`${roomName}_todo`];
+    if (todo) {
+      callback({ success: true, todo });
+    } else {
+      callback({ success: false, message: 'No todo found for this room.' });
+    }
+  });
 
   // 방 퇴장 로직
   socket.on('leave_room', async data => {
-    const { roomName, chatMessages } = data;
-    if (!rooms[`${roomName}_chatMessages`]) {
-      rooms[`${roomName}_chatMessages`] = chatMessages;
-    }
-    requestAISummary(roomName, rooms[`${roomName}_chatMessages`]);
+    const { roomName } = data;
+    // if (!rooms[`${roomName}_chatMessages`]) {
+    //   rooms[`${roomName}_chatMessages`] = chatMessages;
+    // }
+    // requestAISummary(roomName, rooms[`${roomName}_chatMessages`]);
 
     socket.off('audio_chunk', handleAudioChunk);
     console.log(`[Audio] audio_chunk listener removed for room: ${roomName}`);

--- a/src/components/CallScreen.jsx
+++ b/src/components/CallScreen.jsx
@@ -517,22 +517,15 @@ const CallScreen = () => {
       if (socket) {
         console.log('Sending leave_room event to server...');
         socket.off('audio_chunk'); // audio_chunk 리스너 제거
-        socket.emit('leave_room', { roomName, chatMessages });
+        socket.emit('leave_room', { roomName });
+
+        navigate(`/call/end?roomName=${roomName}`, {
+          state: { talkId, chatMessages },
+        });  
         console.log('leave_room event sent successfully.');
       }
     } catch (error) {
       console.error('Error while sending leave_room event:', error);
-    }
-
-    try {
-      // UI 이동 보장
-      console.log('Navigating to /call/end...');
-      navigate(`/call/end?roomName=${roomName}`, {
-        state: { talkId },
-      });      
-      console.log('Navigation to /call/end completed.');
-    } catch (error) {
-      console.error('Error during navigation:', error);
     }
   };
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 요약 요청을 socket에서 axios로 변경
  - 상대방과 받는 todo 통일하기
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. 새 패키지가 설치되었다면 여기에 반드시 명시해 주세요. -->
  - EndCallScreen 입장 시 유저는 AI 서버로 요약 요청을 보냄 (front -> AI 서버) (axios 사용) 
  - 요약 데이터를 프론트에서 받아 Node.js server에 저장 (상대방에게 똑같은 todo를 전달하기 위함) (socket 사용)
  -  상대방의 경우 chatMessages 가 빈 배열로 들어옴, chatMessages가 빈 배열일 경우 서버에 저장해논 todo를 가져옴 (socket)
  - 화면에 출력
 ## 📊 테스트 결과 <!-- 테스트 결과를 간단히 적어주시거나 스크린샷을 첨부해 주세요 -->
  
<img width="473" alt="image" src="https://github.com/user-attachments/assets/ea7b200f-73c9-45eb-b14f-719c39406f04" />
<img width="584" alt="image" src="https://github.com/user-attachments/assets/bccf388e-25b8-466f-8fbd-9451a10a2f07" />

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
  - #66